### PR TITLE
Merge back disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Current state:
 
 Solution: Manually check background layer at anchor locations, paint similar to neighbouring tiles if necessary.
 
+- Objects with even tilewidth have their horizontal placement calculated only approximately. One tile for objects is selected as "anchor tile" against which other coords are calculated. While "uneven" objects do not change their position when flipped (they are flipped regarding to their "center tile"), even objects may shift one tile, or, in case of objects have anchors in corners, by width-1 number of tiles. Heuristics to calculate their position accurately seems too complex to implement.
+
+Solution: Manually shift to required locations referring to key_with_grid PNG file (anchor tiles are painted light red). I'll try to come up with a proper solution, but so far I don't see one.
+
+
 - Objects that have separate sprites for different placements (as opposed to simply flipping single sprite horizontally) use tile with default orientation after conversion. Meaning they can possibly lack mount points, hang in the air or overlap solid blocks, leading to log errors when spawning in-game.
 
 Solution: Manually check such objects and replace with appropriate `_orientationN` versions from the same tileset. Most common cases include light sources (example: glitch torches), diagonal supports (example: wooden, foundry etc), signs (example: glitch village signs).

--- a/src/conversionSteps.ts
+++ b/src/conversionSteps.ts
@@ -171,7 +171,7 @@ async function convertChunk(chunkTodo: DungeonPartTodo, oldTileset:OldTilesetSor
     convertedChunk
   );
   if (success) {
-    console.log(`${chunkTodo.targetName} saved >:3`);
+    console.log(`>${chunkTodo.targetName} saved >:3`);
   }
   return success;
 }

--- a/src/conversionSteps.ts
+++ b/src/conversionSteps.ts
@@ -118,7 +118,7 @@ async function generateDungeonChunk(tilePixels: NdArray<Uint8Array>, objPixels: 
 
       convertedChunk.parseAnchors(objRgbaArray, anchorsMap, log); //let's try to find some anchors here as well
       //map PNG to objects using objectsGidMap
-      await convertedChunk.parseAddObjects(
+      await convertedChunk.parseObjects(
         oldTileset.objects as tilesetMatcher.ObjectTile[],
         objRgbaArray,
         objectsMap,
@@ -171,7 +171,7 @@ async function convertChunk(chunkTodo: DungeonPartTodo, oldTileset:OldTilesetSor
     convertedChunk
   );
   if (success) {
-    console.log(`>${chunkTodo.targetName} saved >:3`);
+    console.log(` ${chunkTodo.targetName} saved >:3`);
   }
   return success;
 }

--- a/src/dungeonChunkAssembler.ts
+++ b/src/dungeonChunkAssembler.ts
@@ -365,14 +365,17 @@ class SbDungeonChunk{
       }
       else {
         if(mergeLayerData[pixelN] !== magicPinkBrushGid && mergeLayerData[pixelN] !== 0) {
-          throw new Error(`Merging layers both have non-empty values at pixel ${pixelN}`)
+          const coords = this.getCoordsFromFlatRgbaArray(pixelN, this.#width);
+          const GidOld = baseLayerData[pixelN];
+          const GidNew = mergeLayerData[pixelN];
+          throw new Error(`Merging layers both have non-empty values at pixel ${pixelN}, coords X ${coords?.x}, Y ${coords?.y}`)
         }
       }
     }
     return baseLayerData;
   }
 
-  mergeTilelayers(frontLayerData: number[], backLayerData: number[], log = false):SbDungeonChunk {
+  mergeTilelayers(frontLayerData: number[], /*backLayerData: number[],*/ log = false):SbDungeonChunk {
     if (log) {
       console.log(`  - merging tilelayers from objects.png`);
     }
@@ -388,7 +391,7 @@ class SbDungeonChunk{
     }
     
     this.#mergeLayerData((this.#layers[frontIndex] as SbTilelayer).data as Array<number>, frontLayerData);
-    this.#mergeLayerData((this.#layers[backIndex] as SbTilelayer).data as Array<number>, backLayerData);
+    //this.#mergeLayerData((this.#layers[backIndex] as SbTilelayer).data as Array<number>, backLayerData);
     return this;
   }
 
@@ -476,6 +479,24 @@ class SbDungeonChunk{
     };
     (this.#layers[layerId] as SbAnchorLayer).objects.push(newAnchor);
     this.#nextobjectid = this.#nextobjectid +1;
+    return this;
+  }
+
+  parseAnchors(rgbaArray: RgbaValueType[], anchorsMatchMap: LayerTileMatchType[], log = false):SbDungeonChunk {
+    if (log) {
+      console.log(`  - adding anchors`);
+    }
+
+    for (let rgbaN = 0; rgbaN < rgbaArray.length; rgbaN++) {
+      for (const match of anchorsMatchMap) {
+        if (match!== undefined && isRgbaEqual(rgbaArray[rgbaN], match.tileRgba)) {
+          const gid = match.tileGid;
+          const { x: anchorX, y: anchorY } = this.getCoordsFromFlatRgbaArray(rgbaN, this.#width);
+          this.addAnchorToObjectLayer(gid, anchorX, anchorY);
+        }
+      }
+    }
+    
     return this;
   }
 

--- a/src/tilesetMatch.ts
+++ b/src/tilesetMatch.ts
@@ -851,7 +851,7 @@ const MISCJSON_MAP = [
     return matchMap;
 }
 
-function matchAnchors(oldAnchorsArray: AnchorTile[], miscTilesetJSON: TilesetMiscJson, firstGid: number): (LayerTileMatch|undefined)[] {
+function matchAnchors(oldAnchorsArray: AnchorTile[], miscTilesetJSON: TilesetMiscJson, firstGid: number): LayerTileMatch[] {
   
   function ruleGetName(rule: typeof ANCHOR_RULES[number]): string {
     let ruleName: string = rule;
@@ -934,7 +934,10 @@ function matchAnchors(oldAnchorsArray: AnchorTile[], miscTilesetJSON: TilesetMis
     
     return; //skip tile if no matches
   });
-  return matchMap;
+  //return using typeguard to avoid TS complaining too much
+  return matchMap.filter((match):match is LayerTileMatch => {
+    return match !== undefined;
+  });
 }
 
 function matchObjects(oldObjectsArray: ObjectTile[], tileset: TilesetObjectJson, partialMatchMap: (ObjectTileMatch|undefined)[]): (ObjectTileMatch|undefined)[] {


### PR DESCRIPTION
Disable merging background tiles from objects.PNG into the main file. Converter assumes that objects.PNG does not contain any info on background tiles and will ignore them.